### PR TITLE
ENH: Add subinterfaces.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -92,7 +92,7 @@ html_theme = "sphinx_rtd_theme"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+# html_static_path = ["_static"]
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/docs/errors.rst
+++ b/docs/errors.rst
@@ -1,3 +1,5 @@
+.. _error-detection:
+
 Error Detection
 ---------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@
 :mod:`interface` is a library for declaring interfaces and for statically
 asserting that classes implement those interfaces. It provides stricter
 semantics than Python's built-in :mod:`abc` module, and it aims to produce
-`exceptionally useful error messages`_ when interfaces aren't satisfied.
+:ref:`exceptionally useful error messages <error-detection>` when interfaces aren't satisfied.
 
 :mod:`interface` supports Python 2.7 and Python 3.4+.
 
@@ -50,5 +50,3 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-
-.. _`exceptionally useful error messages` : errors.html

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -172,3 +172,42 @@ of ``get_all``:
 
    Consider changing ReadOnlyMapping.get_all or making these attributes part of ReadOnlyMapping.
       class ReadOnlyMapping(interface.Interface):
+
+Interface Subclassing
+~~~~~~~~~~~~~~~~~~~~~
+
+Interfaces can inherit requirements from other interfaces via subclassing. For
+example, if we want to create interfaces for read-write and read-only mappings,
+we could do so as follows:
+
+.. code-block:: python
+
+   class ReadOnlyMapping(interface.Interface):
+       def get(self, key):
+           pass
+
+       def keys(self):
+           pass
+
+
+   class ReadWriteMapping(ReadOnlyMapping):
+
+       def set(self, key, value):
+           pass
+
+       def delete(self, key):
+           pass
+
+
+An interface that subclasses from another interface inherits all the function
+signature requirements from its parent interface. In the example above, a class
+implementing ``ReadWriteMapping`` would have to implement ``get``, ``keys``,
+``set``, and ``delete``.
+
+.. warning::
+
+   Subclassing from an interface is not the same as implementing an
+   interface. Subclassing from an interface **creates a new interface** that
+   adds additional methods to the parent interface. Implementing an interface
+   creates a new class whose method signatures must be compatible with the
+   interface being implemented.

--- a/interface/functional.py
+++ b/interface/functional.py
@@ -46,3 +46,16 @@ def sliding_window(iterable, n):
     for item in it:
         items.append(item)
         yield tuple(items)
+
+
+def merge(dicts):
+    dicts = list(dicts)
+    if len(dicts) == 0:
+        return {}
+    elif len(dicts) == 1:
+        return dicts[0]
+    else:
+        out = dicts[0].copy()
+        for other in dicts[1:]:
+            out.update(other)
+        return out

--- a/interface/tests/_py3_typecheck_tests.py
+++ b/interface/tests/_py3_typecheck_tests.py
@@ -1,14 +1,13 @@
-from inspect import signature
-
 from ..typecheck import compatible
+from ..typed_signature import TypedSignature
 
 
 def test_allow_new_params_with_defaults_with_kwonly():
-    @signature
+    @TypedSignature
     def iface(a, b, c):  # pragma: nocover
         pass
 
-    @signature
+    @TypedSignature
     def impl(a, b, c, d=3, e=5, *, f=5):  # pragma: nocover
         pass
 
@@ -17,11 +16,11 @@ def test_allow_new_params_with_defaults_with_kwonly():
 
 
 def test_allow_reorder_kwonlys():
-    @signature
+    @TypedSignature
     def foo(a, b, c, *, d, e, f):  # pragma: nocover
         pass
 
-    @signature
+    @TypedSignature
     def bar(a, b, c, *, f, d, e):  # pragma: nocover
         pass
 
@@ -30,11 +29,11 @@ def test_allow_reorder_kwonlys():
 
 
 def test_allow_default_changes():
-    @signature
+    @TypedSignature
     def foo(a, b, c=3, *, d=1, e, f):  # pragma: nocover
         pass
 
-    @signature
+    @TypedSignature
     def bar(a, b, c=5, *, f, e, d=12):  # pragma: nocover
         pass
 
@@ -43,11 +42,11 @@ def test_allow_default_changes():
 
 
 def test_disallow_kwonly_to_positional():
-    @signature
+    @TypedSignature
     def foo(a, *, b):  # pragma: nocover
         pass
 
-    @signature
+    @TypedSignature
     def bar(a, b):  # pragma: nocover
         pass
 

--- a/interface/tests/test_typecheck.py
+++ b/interface/tests/test_typecheck.py
@@ -1,16 +1,16 @@
-from ..compat import PY3, signature
+from ..compat import PY3
 from ..typecheck import compatible
 from ..typed_signature import TypedSignature
 
 
 def test_compatible_when_equal():
-    @signature
+    @TypedSignature
     def foo(a, b, c):  # pragma: nocover
         pass
 
     assert compatible(foo, foo)
 
-    @signature
+    @TypedSignature
     def bar():  # pragma: nocover
         pass
 
@@ -18,11 +18,11 @@ def test_compatible_when_equal():
 
 
 def test_disallow_new_or_missing_positionals():
-    @signature
+    @TypedSignature
     def foo(a, b):  # pragma: nocover
         pass
 
-    @signature
+    @TypedSignature
     def bar(a):  # pragma: nocover
         pass
 
@@ -31,11 +31,11 @@ def test_disallow_new_or_missing_positionals():
 
 
 def test_disallow_remove_defaults():
-    @signature
+    @TypedSignature
     def iface(a, b=3):  # pragma: nocover
         pass
 
-    @signature
+    @TypedSignature
     def impl(a, b):  # pragma: nocover
         pass
 
@@ -43,11 +43,11 @@ def test_disallow_remove_defaults():
 
 
 def test_disallow_reorder_positionals():
-    @signature
+    @TypedSignature
     def foo(a, b):  # pragma: nocover
         pass
 
-    @signature
+    @TypedSignature
     def bar(b, a):  # pragma: nocover
         pass
 
@@ -56,11 +56,11 @@ def test_disallow_reorder_positionals():
 
 
 def test_allow_new_params_with_defaults_no_kwonly():
-    @signature
+    @TypedSignature
     def iface(a, b, c):  # pragma: nocover
         pass
 
-    @signature
+    @TypedSignature
     def impl(a, b, c, d=3, e=5, f=5):  # pragma: nocover
         pass
 
@@ -73,5 +73,38 @@ def test_first_argument_name():
     assert TypedSignature(lambda: 0).first_argument_name is None
 
 
-if PY3:  # pragma: nocover
+def test_typed_signature_repr():
+    @TypedSignature
+    def foo(a, b, c):  # pragma: nocover
+        pass
+
+    expected = "<TypedSignature type=function, signature=(a, b, c)>"
+    assert repr(foo) == expected
+
+    @TypedSignature
+    @property
+    def bar(a, b, c):  # pragma: nocover
+        pass
+
+    expected = "<TypedSignature type=property, signature=(a, b, c)>"
+    assert repr(bar) == expected
+
+    @TypedSignature
+    @classmethod
+    def baz(a, b, c):  # pragma: nocover
+        pass
+
+    expected = "<TypedSignature type=classmethod, signature=(a, b, c)>"
+    assert repr(baz) == expected
+
+    @TypedSignature
+    @staticmethod
+    def fizz(a, b, c):  # pragma: nocover
+        pass
+
+    expected = "<TypedSignature type=staticmethod, signature=(a, b, c)>"
+    assert repr(fizz) == expected
+
+
+if PY3:  # pragma: nocover-py2
     from ._py3_typecheck_tests import *  # noqa

--- a/interface/tests/test_utils.py
+++ b/interface/tests/test_utils.py
@@ -1,4 +1,5 @@
 from ..compat import unwrap, wraps
+from ..functional import merge
 from ..utils import is_a, unique
 
 
@@ -20,3 +21,11 @@ def test_wrap_and_unwrap():
         pass
 
     assert unwrap(g) is f
+
+
+def test_merge():
+    assert merge([]) == {}
+    assert merge([{"a": 1, "b": 2}]) == {"a": 1, "b": 2}
+
+    result = merge([{"a": 1}, {"b": 2}, {"a": 3, "c": 4}])
+    assert result == {"a": 3, "b": 2, "c": 4}

--- a/interface/typecheck.py
+++ b/interface/typecheck.py
@@ -13,9 +13,9 @@ def compatible(impl_sig, iface_sig):
 
     Parameters
     ----------
-    impl_sig : inspect.Signature
+    impl_sig : interface.typed_signature.TypedSignature
         The signature of the implementation function.
-    iface_sig : inspect.Signature
+    iface_sig : interface.typed_signature.TypedSignature
         The signature of the interface function.
 
     In general, an implementation is compatible with an interface if any valid
@@ -37,6 +37,9 @@ def compatible(impl_sig, iface_sig):
        b. The return type of an implementation may be annotated with a
           **subclass** of the type specified by the interface.
     """
+    # Unwrap to get the underlying inspect.Signature objects.
+    impl_sig = impl_sig.signature
+    iface_sig = iface_sig.signature
     return all(
         [
             positionals_compatible(

--- a/interface/typed_signature.py
+++ b/interface/typed_signature.py
@@ -45,6 +45,11 @@ class TypedSignature(object):
     def __str__(self):
         return str(self._signature)
 
+    def __repr__(self):
+        return "<TypedSignature type={}, signature={}>".format(
+            self._type.__name__, self._signature,
+        )
+
 
 BUILTIN_FUNCTION_TYPES = (types.FunctionType, types.BuiltinFunctionType)
 


### PR DESCRIPTION
Add support for creating sub-interfaces by subclassing from an interface.

A sub interface inherits all the interface members of its parents, and may add
new interface items. It can also override parent members with new signatures,
provided that any implementation of the child interface is also a valid
implementation of the parent interface.